### PR TITLE
Fixed local broadcast address calculation and MAC address when in AP mode

### DIFF
--- a/src/ArtnetnodeWifi.cpp
+++ b/src/ArtnetnodeWifi.cpp
@@ -62,7 +62,12 @@ uint8_t ArtnetnodeWifi::begin(String hostname)
   }
   else {
     localIP = WiFi.softAPIP();
-    localMask = IPAddress(255,255,255,0);
+    struct ip_info info;
+    if(wifi_get_ip_info(SOFTAP_IF, &info)) {
+      localMask = info.netmask.addr;
+    } else { 
+      localMask = IPAddress(255, 255, 255, 0);
+    }
     WiFi.softAPmacAddress(mac);
   }
   localBroadcast = IPAddress((uint32_t)localIP | ~(uint32_t)localMask);

--- a/src/ArtnetnodeWifi.cpp
+++ b/src/ArtnetnodeWifi.cpp
@@ -55,8 +55,14 @@ uint8_t ArtnetnodeWifi::begin(String hostname)
   byte mac[6];
 
   Udp.begin(ARTNET_PORT);
-  localIP = WiFi.localIP();
-  localMask = WiFi.subnetMask();
+  if (WiFi.getMode() == WIFI_STA || WiFi.getMode() == WIFI_AP_STA) {
+    localIP = WiFi.localIP();
+    localMask = WiFi.subnetMask();
+  }
+  else {
+    localIP = WiFi.softAPIP();
+    localMask = IPAddress(255,255,255,0);
+  }
   localBroadcast = IPAddress((uint32_t)localIP | ~(uint32_t)localMask);
 
   WiFi.macAddress(mac);

--- a/src/ArtnetnodeWifi.cpp
+++ b/src/ArtnetnodeWifi.cpp
@@ -55,17 +55,18 @@ uint8_t ArtnetnodeWifi::begin(String hostname)
   byte mac[6];
 
   Udp.begin(ARTNET_PORT);
-  if (WiFi.getMode() == WIFI_STA || WiFi.getMode() == WIFI_AP_STA) {
+  if (WiFi.getMode() == WIFI_STA) {
     localIP = WiFi.localIP();
     localMask = WiFi.subnetMask();
+    WiFi.macAddress(mac);
   }
   else {
     localIP = WiFi.softAPIP();
     localMask = IPAddress(255,255,255,0);
+    WiFi.softAPmacAddress(mac);
   }
   localBroadcast = IPAddress((uint32_t)localIP | ~(uint32_t)localMask);
 
-  WiFi.macAddress(mac);
   PollReplyPacket.setMac(mac);
   PollReplyPacket.setIP(localIP);
   PollReplyPacket.canDHCP(true);


### PR DESCRIPTION
Local IP, local mask and MAC address must be calculated in different way when in STA or AP mode. 

Local mask in AP mode is set to 255.255.255.0 because there are no method to get the actual value. It works when AP is set with default values.